### PR TITLE
Fixes a bug, where a route without leading slash throws an error while npm run generate

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -15,7 +15,7 @@ let extractPayload = function(html, route){
 }
 
 let writePayload = function(payload, route, root){
-  let dir = root + route
+  let dir = path.resolve(root, route)
 
   let subpath = root
   for(let subdir of route.split('/')){


### PR DESCRIPTION
I run into a problem when trying this module for a current project. 

My routes for the `generate` command were:  `['page1', 'page2]`. When running `npm run generate` an error occured because the path for `payload.js` was `[…]/distpage1/payload.js` because there's no leading slash in my route item. 

This PR fixes this and makes it does't matter if there's a leading slash or not 👍