### PR TITLE
Feature/subfolders

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,34 @@
+export const getFsFileName = ({
+  root,
+  route,
+  extension,
+  timestamp = "",
+  subFolders,
+}) => {
+  // Index route
+  if (route === "/") return path.join(root, `payload${timestamp}.${extension}`);
+  // Not using subfolders
+  if (subFolders === false)
+    return `${path.join(root, ...route.split("/"))}${timestamp}.${extension}`;
+  // Using subfolders
+  return path.join(
+    root,
+    ...route.split("/"),
+    `payload${timestamp}.${extension}`
+  );
+};
+
+export const getUrlFileName = ({
+  base,
+  route,
+  extension,
+  timestamp = "",
+  subFolders,
+}) => {
+  // Index route
+  if (route === "/") return `${base}/payload${timestamp}.${extension}`;
+  // Not using subfolders
+  if (subFolders === false) return `${base}${route}${timestamp}.${extension}`;
+  // Using subfolders
+  return `${base}${route}/payload${timestamp}.${extension}`;
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,5 @@
+import path from 'path'
+
 export const getFsFileName = ({
   root,
   route,
@@ -8,7 +10,7 @@ export const getFsFileName = ({
   // Index route
   if (route === "/") return path.join(root, `payload${timestamp}.${extension}`);
   // Not using subfolders
-  if (subFolders === false)
+  if (subFolders === false || subFolders === 'false')
     return `${path.join(root, ...route.split("/"))}${timestamp}.${extension}`;
   // Using subfolders
   return path.join(
@@ -28,7 +30,7 @@ export const getUrlFileName = ({
   // Index route
   if (route === "/") return `${base}/payload${timestamp}.${extension}`;
   // Not using subfolders
-  if (subFolders === false) return `${base}${route}${timestamp}.${extension}`;
+  if (subFolders === false || subFolders === 'false') return `${base}${route}${timestamp}.${extension}`;
   // Using subfolders
   return `${base}${route}/payload${timestamp}.${extension}`;
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,18 +4,18 @@ export const getFsFileName = ({
   root,
   route,
   extension,
-  timestamp = "",
+  timestamp = '',
   subFolders,
 }) => {
   // Index route
-  if (route === "/") return path.join(root, `payload${timestamp}.${extension}`);
+  if (route === '/') return path.join(root, `payload${timestamp}.${extension}`);
   // Not using subfolders
   if (subFolders === false || subFolders === 'false')
-    return `${path.join(root, ...route.split("/"))}${timestamp}.${extension}`;
+    return `${path.join(root, ...route.split('/'))}${timestamp}.${extension}`;
   // Using subfolders
   return path.join(
     root,
-    ...route.split("/"),
+    ...route.split('/'),
     `payload${timestamp}.${extension}`
   );
 };
@@ -24,11 +24,11 @@ export const getUrlFileName = ({
   base,
   route,
   extension,
-  timestamp = "",
+  timestamp = '',
   subFolders,
 }) => {
   // Index route
-  if (route === "/") return `${base}/payload${timestamp}.${extension}`;
+  if (route === '/') return `${base}/payload${timestamp}.${extension}`;
   // Not using subfolders
   if (subFolders === false || subFolders === 'false') return `${base}${route}${timestamp}.${extension}`;
   // Using subfolders

--- a/lib/module.js
+++ b/lib/module.js
@@ -17,14 +17,8 @@ let extractPayload = function(html, route, base, timestamp, subFolders){
   }
 }
 
-let getAbsoluteDir = function(root, route) {
-  let normalizedRoute = route[0] === '/' ? route : '/' + route
-  return root + normalizedRoute
-}
 
 let writePayload = function(payload, route, root, timestamp, subFolders){
-  let dir = getAbsoluteDir(root, route)
-
   let subpath = root
   let dirsToCreate = route.split('/')
   if (subFolders === false) {
@@ -32,7 +26,7 @@ let writePayload = function(payload, route, root, timestamp, subFolders){
   }
   for(let subdir of dirsToCreate){
     if(subdir){
-      path.join(subpath, subdir)
+      subpath = path.join(subpath, subdir)
       if (!fs.existsSync(subpath)) fs.mkdirSync(subpath)
     }
   }
@@ -85,7 +79,13 @@ module.exports = function extractor({ blacklist, versioning = true }) {
     return page
   })
 
+  this.addTemplate({
+    fileName: 'payload-extractor/helpers.js',
+    src: path.resolve(__dirname, 'helpers.js')
+  })
+
   this.addPlugin({
+    fileName: 'payload-extractor/plugin.js',
     src: path.resolve(__dirname, 'plugin.js'),
     options: {
       timestamp,

--- a/lib/module.js
+++ b/lib/module.js
@@ -6,7 +6,7 @@ const { getFsFileName, getUrlFileName } = require('./helpers')
 const payloadKey = '__NUXT__'
 
 let extractPayload = function(html, route, base, timestamp, subFolders){
-  let chunks = html.split('<script>window.__NUXT__=')
+  let chunks = html.split(`<script>window.${payloadKey}=`)
   let pre = chunks[0]
   let payload = chunks[1].split('</script>').shift()
   let post = chunks[1].split('</script>').slice(1).join('</script>')

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,17 +1,18 @@
 const fs = require('fs')
 const path = require('path')
 
+const { getFsFileName, getUrlFileName } = require('./helpers')
+
 const payloadKey = '__NUXT__'
 
-let extractPayload = function(html, route, base, timestamp){
+let extractPayload = function(html, route, base, timestamp, subFolders){
   let chunks = html.split('<script>window.__NUXT__=')
   let pre = chunks[0]
   let payload = chunks[1].split('</script>').shift()
   let post = chunks[1].split('</script>').slice(1).join('</script>')
-  let path = route === '/' ? '' : route
 
   return {
-    html: pre + '<script defer src="' + base + path + '/payload' + timestamp + '.js"></script>' + post,
+    html: pre + '<script defer src="' + getUrlFileName({ base, route, extension: 'js', timestamp, subFolders }) + '"></script>' + post,
     payload
   }
 }
@@ -38,7 +39,7 @@ let writePayload = function(payload, route, root, timestamp, subFolders){
 
   let payloadBody = `window.${payloadKey}=${payload}`
 
-  fs.writeFile(path.resolve(dir, `payload${timestamp}.js`), payloadBody, 'utf8', err => {
+  fs.writeFile(getFsFileName({ root, route, extension: 'js', timestamp, subFolders }), payloadBody, 'utf8', err => {
     if (err) return console.error(err);
   });
 
@@ -54,7 +55,7 @@ let writePayload = function(payload, route, root, timestamp, subFolders){
       return { ...prev, ...current }
     }, {})
 
-  fs.writeFile(path.resolve(dir, `payload${timestamp}.json`), availableData ? JSON.stringify(availableData) : '', 'utf8', err => {
+  fs.writeFile(getFsFileName({ root, route, extension: 'json', timestamp, subFolders }), availableData ? JSON.stringify(availableData) : '{}', 'utf8', err => {
     if (err) return console.error(err)
   })
 }
@@ -74,7 +75,6 @@ module.exports = function extractor({ blacklist, versioning = true }) {
   }
 
   this.nuxt.hook('generate:page', async page => {
-    if(!this.nuxt.options.generate.subFolders) throw new Error('generate.subFolders should be true for nuxt-payload-extractor')
     if(blacklist && blacklist.includes(page.route)) return page
 
     let { html, payload } = extractPayload(page.html, page.route, base, timestamp, subFolders)

--- a/lib/module.js
+++ b/lib/module.js
@@ -21,13 +21,17 @@ let getAbsoluteDir = function(root, route) {
   return root + normalizedRoute
 }
 
-let writePayload = function(payload, route, root, timestamp){
+let writePayload = function(payload, route, root, timestamp, subFolders){
   let dir = getAbsoluteDir(root, route)
 
   let subpath = root
-  for(let subdir of route.split('/')){
+  let dirsToCreate = route.split('/')
+  if (subFolders === false) {
+    dirsToCreate.splice(-1, 1)
+  }
+  for(let subdir of dirsToCreate){
     if(subdir){
-      subpath += '/' + subdir
+      path.join(subpath, subdir)
       if (!fs.existsSync(subpath)) fs.mkdirSync(subpath)
     }
   }
@@ -62,6 +66,7 @@ module.exports = function extractor({ blacklist, versioning = true }) {
   const distDir = this.nuxt.options.generate.dir
   const routerBase = this.nuxt.options.router.base
   const base = routerBase.slice(0, -1)
+  const subFolders = this.nuxt.options.generate.subFolders
 
   if (this.nuxt.options.mode === 'spa') {
     console.warn('nuxt generate is running in spa-only mode, so nuxt-payload-extractor will be ignored')
@@ -72,8 +77,8 @@ module.exports = function extractor({ blacklist, versioning = true }) {
     if(!this.nuxt.options.generate.subFolders) throw new Error('generate.subFolders should be true for nuxt-payload-extractor')
     if(blacklist && blacklist.includes(page.route)) return page
 
-    let { html, payload } = extractPayload(page.html, page.route, base, timestamp)
-    writePayload(payload, page.route, distDir, timestamp)
+    let { html, payload } = extractPayload(page.html, page.route, base, timestamp, subFolders)
+    writePayload(payload, page.route, distDir, timestamp, subFolders)
 
     page.html = html
 
@@ -84,7 +89,8 @@ module.exports = function extractor({ blacklist, versioning = true }) {
     src: path.resolve(__dirname, 'plugin.js'),
     options: {
       timestamp,
-      base
+      base,
+      subFolders
     }
   })
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,9 +1,11 @@
-export default (ctx) => {
-  ctx.$payloadURL = route => {
-    const fileName = 'payload<%= options.timestamp %>.json'
-    const base = '<%= options.base %>'
-    const normalizedPath = route.path.replace(/\/+$/, '')
+import { getUrlFileName } from './helpers'
 
-    return document.location.origin + base + normalizedPath + '/' + fileName
+export default (ctx, options) => {
+  ctx.$payloadURL = route => {
+    const timestamp = '<%= options.timestamp %>'
+    const base = '<%= options.base %>'
+    const subFolders = '<%= options.subFolders %>'
+
+    return document.location.origin + getUrlFileName({ base, extension: 'json', route, timestamp, subFolders })
   }
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -5,7 +5,13 @@ export default (ctx, options) => {
     const base = '<%= options.base %>'
     const timestamp = '<%= options.timestamp %>'
     const subFolders = '<%= options.subFolders %>'
-
-    return document.location.origin + getUrlFileName({ base, extension: 'json', route, timestamp, subFolders })
+    const filePath = getUrlFileName({ 
+      extension: 'json', 
+      route: route.path, 
+      subFolders,
+      timestamp, 
+      base, 
+    })
+    return document.location.origin + filePath
   }
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,8 +2,8 @@ import { getUrlFileName } from './helpers'
 
 export default (ctx, options) => {
   ctx.$payloadURL = route => {
-    const timestamp = '<%= options.timestamp %>'
     const base = '<%= options.base %>'
+    const timestamp = '<%= options.timestamp %>'
     const subFolders = '<%= options.subFolders %>'
 
     return document.location.origin + getUrlFileName({ base, extension: 'json', route, timestamp, subFolders })

--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
     "type": "git",
     "url": "git+https://github.com/DreaMinder/nuxt-payload-extractor.git"
   },
-  "version": "1.0.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
Hello!
Thanks you for this package, very useful. I wanted to use it with `subFolders` set to false, so updated the code for that.

It works the same as before if `subFolders` is not set to `false`.
If the `subFolders` options is set to `false` the generated files will be the same as the page's name. So for example for `/example` route the generated html will be `example.html` the JS file will be `example.js` and the extracted data will be `example.json`. (for the index route, `/` it will use the `index.js` and `index.json` files).