### PR TITLE
Add descriptive error message when bad payload

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -37,7 +37,9 @@ let writePayload = function(payload, route, root, timestamp, subFolders){
     if (err) return console.error(err);
   });
 
-  let data = eval('('+payload+')')
+  let data
+  try { data = eval('('+payload+')') }
+  catch (e) { throw `writePayload error for ${route}: ${e.message}` }
 
   // if routes are nested, merge them into one object
   let availableData = data.data


### PR DESCRIPTION
Some bad CMS content was resulting in errors when running `eval()` here.  This adds some logging of the erring route to help folks diagnose such issues.